### PR TITLE
Fix file lock issue (on windows)

### DIFF
--- a/cropclassification/preprocess/timeseries_calc_dias_onda_per_image.py
+++ b/cropclassification/preprocess/timeseries_calc_dias_onda_per_image.py
@@ -1313,17 +1313,22 @@ def projected_bounds_to_window(
 
     return window_to_read
 
-def create_file_atomic(filename: Path):
+def create_file_atomic(path: Path):
     """
     Create a lock file in an atomic way, so it is threadsafe.
 
     Returns True if the file was created by this thread, False if the file existed already.
     """
+    fd = None
     try:
-        os.open(filename,  os.O_CREAT | os.O_EXCL)
+        fd = os.open(path,  os.O_CREAT | os.O_EXCL)
         return True
     except FileExistsError:
         return False
+    finally:
+        if fd is not None:
+            os.close(fd)
+
 
 def prepare_image(
         image_path: Path,


### PR DESCRIPTION
Symptom: error when trying to unlink the file.

Issue explicitly seen and easy reproducable on windows. On linux not immediately/consistently reproducable, but most likely it is also possible to occur.