### PR TITLE
ENH: If image period is e.g. "weekly", align `start_date` of a marker to the next monday instead of the previous one

### DIFF
--- a/cropclassification/general.ini
+++ b/cropclassification/general.ini
@@ -42,6 +42,15 @@ reuse_last_run_dir_config = False
 # The calc_periodic_mosaic_params section contains information to run a calc_marker task
 [calc_periodic_mosaic_params]
 
+# Depending on the period_name specified in the ImageProfiles, the `start_date` and
+# `end_date` will be adjusted:
+#   - "weekly": image periods will start on a monday and end on a sunday. If the
+#     `start_date` is no monday, the first monday following it will be used. If the
+#     `end_date` (exclusive) is no monday, the first monday before it will be used.
+#   - "biweekly": image periods will start on even mondays of the year. If the
+#      `start_date` is no monday, the first even monday following it will be used.
+#      If the `end_date` (exclusive) is no monday, the first even monday before it
+#      will be used.
 # The start date of the period we want to download the mosaic
 start_date_str = MUST_OVERRIDE
 # The end date of the period we want to download the mosaic
@@ -88,18 +97,20 @@ roi_bounds = MUST_OVERRIDE
 # The crs the roi bounds are specified in
 roi_crs = MUST_OVERRIDE
 
+# For more information about how the start and end dates map to image periodes, check
+# the calc_periodic_mosaic_params section.
+# Remark: year will be replace in run-time
 # start date of timeseries data to use
-# remarks: nearest monday will be used + year will be replace in run-time
 start_date_str = ${year}-03-27 
-# end date of timeseries data to use
-# remarks: end date is NOT inclusive + year will be replace in run-time
+# end date of timeseries data to use, NOT inclusive
 end_date_str = ${year}-08-10
 
 # negative buffer to apply to input parcels
 buffer = 5
 # minimum number of pixels that should be inside the buffered input parcels
 min_nb_pixels = -2 
-# minimum number of pixels that should be inside the buffered input parcels used when training
+# minimum number of pixels that should be inside the buffered input parcels used when
+# training
 min_nb_pixels_train = ${marker:min_nb_pixels}
 
 # classes that will be ignored for training + won't receive a prediction

--- a/cropclassification/util/date_util.py
+++ b/cropclassification/util/date_util.py
@@ -2,12 +2,14 @@ from datetime import datetime
 from typing import Union
 
 
-def get_monday(date: Union[str, datetime]) -> datetime:
+def get_monday(date: Union[str, datetime], before: bool = True) -> datetime:
     """
-    If date is no monday yet, return the first monday before it.
+    If date is no monday yet, return the monday before or after it.
 
     Args:
        date (datetime, str): if a string, expected format: %Y-%m-%d
+       before (bool): if True, return the monday before the date, otherwise the monday
+        after. Defaults to True.
 
     Return
         datetime: a monday.
@@ -15,29 +17,46 @@ def get_monday(date: Union[str, datetime]) -> datetime:
     if isinstance(date, str):
         date = datetime.strptime(date, "%Y-%m-%d")
 
-    year_week = date.strftime("%Y_%W")
-    year_week_monday = datetime.strptime(year_week + "_1", "%Y_%W_%w")
+    # It is already a monday, so return it.
+    if date.strftime("%w") == "1":
+        return date
+
+    # Determine the monday before or after the date
+    year = date.strftime("%Y")
+    week = int(date.strftime("%W"))
+    if not before:
+        week += 1
+    year_week_monday = datetime.strptime(f"{year}_{week:02d}_1", "%Y_%W_%w")
+
     return year_week_monday
 
 
-def get_monday_biweekly(date: Union[str, datetime]) -> datetime:
+def get_monday_biweekly(date: Union[str, datetime], before: bool = True) -> datetime:
     """
-    This function gets the first monday before the date provided, aligned to the every
-    second week of the year.
+    Determines the "biweekly" monday for the date provided.
+
+    In practice the first monday before or after the date will be returned, aligned to
+    every second week of the year.
 
     Args:
        date (datetime, str): if a string, expected format: %Y-%m-%d
+       before (bool): if True, return the monday before the date, otherwise the monday
+            after. Defaults to True.
 
     Return
         datetime: a monday.
     """
-    # First determine the previous monday
-    monday = get_monday(date)
+    # First determine the monday before or after the date
+    monday = get_monday(date, before=before)
 
     # If the week number is even, it is not a "biweekly monday", so we need to move
-    # another monday forward...
+    # another monday forward/backward...
     monday_week = int(monday.strftime("%W"))
     if monday_week % 2 == 0:
-        monday = datetime.strptime(f"{monday.year}_{monday_week-1}_1", "%Y_%W_%w")
+        if before:
+            monday_week -= 1
+        else:
+            monday_week += 1
+        monday = datetime.strptime(f"{monday.year}_{monday_week}_1", "%Y_%W_%w")
 
     return monday

--- a/tests/test_date_util.py
+++ b/tests/test_date_util.py
@@ -5,29 +5,41 @@ from cropclassification.util import date_util
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "input, before, expected",
     [
-        ("2024-01-01", datetime(2024, 1, 1)),
-        ("2024-01-05", datetime(2024, 1, 1)),
-        ("2023-01-01", datetime(2022, 12, 26)),
-        (datetime(2024, 1, 5), datetime(2024, 1, 1)),
+        ("2024-01-01", True, datetime(2024, 1, 1)),
+        ("2024-01-05", True, datetime(2024, 1, 1)),
+        ("2023-01-01", True, datetime(2022, 12, 26)),
+        (datetime(2024, 1, 5), True, datetime(2024, 1, 1)),
+        ("2024-01-01", False, datetime(2024, 1, 1)),
+        ("2024-01-05", False, datetime(2024, 1, 8)),
+        ("2022-12-27", False, datetime(2023, 1, 2)),
+        (datetime(2024, 1, 5), False, datetime(2024, 1, 8)),
     ],
 )
-def test_get_monday(input, expected):
-    assert date_util.get_monday(input) == expected
+def test_get_monday(input, before, expected):
+    result = date_util.get_monday(input, before=before)
+    assert result == expected
+    assert result.strftime("%w") == "1"
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "input, before, expected",
     [
-        ("2024-01-01", datetime(2024, 1, 1)),
-        ("2024-01-05", datetime(2024, 1, 1)),
-        ("2024-01-10", datetime(2024, 1, 1)),
-        ("2023-01-01", datetime(2022, 12, 19)),
-        (datetime(2024, 1, 5), datetime(2024, 1, 1)),
-        (datetime(2024, 2, 1), datetime(2024, 1, 29)),
-        (datetime(2024, 2, 5), datetime(2024, 1, 29)),
+        ("2024-01-01", True, datetime(2024, 1, 1)),
+        ("2024-01-05", True, datetime(2024, 1, 1)),
+        ("2024-01-10", True, datetime(2024, 1, 1)),
+        ("2023-01-01", True, datetime(2022, 12, 19)),
+        (datetime(2024, 1, 5), True, datetime(2024, 1, 1)),
+        (datetime(2024, 2, 1), True, datetime(2024, 1, 29)),
+        (datetime(2024, 2, 5), True, datetime(2024, 1, 29)),
+        ("2024-01-01", False, datetime(2024, 1, 1)),
+        ("2024-01-05", False, datetime(2024, 1, 15)),
+        ("2024-01-10", False, datetime(2024, 1, 15)),
+        ("2022-12-20", False, datetime(2023, 1, 2)),
     ],
 )
-def test_get_monday_biweekly(input, expected):
-    assert date_util.get_monday_biweekly(input) == expected
+def test_get_monday_biweekly(input, before, expected):
+    result = date_util.get_monday_biweekly(input, before=before)
+    assert result == expected
+    assert result.strftime("%w") == "1"

--- a/tests/test_mosaic_util.py
+++ b/tests/test_mosaic_util.py
@@ -165,27 +165,20 @@ def test_ImageProfile_openeo():
 
 
 @pytest.mark.parametrize(
-    "start_date, end_date, period_name, days_per_period, expected_nb_periods",
-    [(datetime(2024, 1, 1), datetime(2024, 1, 17), None, 7, 2)],
+    "start_date, end_date, period_name, period_days, expected_nb_periods",
+    [
+        (datetime(2024, 1, 1), datetime(2024, 1, 17), None, 7, 2),
+        (datetime(2024, 1, 1), datetime(2024, 1, 17), "weekly", None, 2),
+        (datetime(2024, 1, 2), datetime(2024, 1, 17), "weekly", None, 1),
+        (datetime(2024, 1, 1), datetime(2024, 1, 30), "biweekly", None, 2),
+        (datetime(2024, 1, 2), datetime(2024, 1, 30), "biweekly", None, 1),
+    ],
 )
 def test_prepare_periods(
-    start_date, end_date, period_name, days_per_period, expected_nb_periods
+    start_date, end_date, period_name, period_days, expected_nb_periods
 ):
     result = mosaic_util._prepare_periods(
-        start_date, end_date, period_name=period_name, period_days=days_per_period
-    )
-    assert len(result) == expected_nb_periods
-
-
-@pytest.mark.parametrize(
-    "start_date, end_date, days_per_period, expected_nb_periods",
-    [(datetime(2024, 1, 1), datetime(2024, 1, 17), 7, 2)],
-)
-def test_prepare_periods_days_per_period(
-    start_date, end_date, days_per_period, expected_nb_periods
-):
-    result = mosaic_util._prepare_periods(
-        start_date, end_date, period_name=None, period_days=days_per_period
+        start_date, end_date, period_name=period_name, period_days=period_days
     )
     assert len(result) == expected_nb_periods
 
@@ -193,13 +186,20 @@ def test_prepare_periods_days_per_period(
 @pytest.mark.parametrize(
     "exp_error, start_date, end_date, period_name, period_days",
     [
-        ("start_date == end_date", datetime(2024, 1, 1), datetime(2024, 1, 1), None, 7),
         (
             "period_name is None and period_days is not 7 or 14",
             datetime(2024, 1, 1),
             datetime(2024, 1, 2),
             None,
             3,
+        ),
+        ("start_date == end_date", datetime(2024, 1, 1), datetime(2024, 1, 1), None, 7),
+        (
+            "start_date == end_date",
+            datetime(2024, 1, 2),
+            datetime(2024, 1, 26),
+            "biweekly",
+            None,
         ),
     ],
 )


### PR DESCRIPTION
If image period is e.g. "weekly", align `start_date` of a marker to the next monday instead of the previous one. This way we avoid using data outside the dates provided, which is more logical.