### PR TITLE
BUG: fix nb_predict_correct is alway 0 on accuracy report 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@
 - Add whether a parcel has been used for training to output (#107)
 - Run `bulk_zonal_stats` in low priority worker processes (#81)
 - Use ruff instead of black and flake for formatting and linting (#57, #64, #65, #67)
-- Fix pandas 3,... deprecations, warnings (#88, #109)
+- Updates to avoid warnings from (newer versions of) dependencies like pandas,
+  geofileops (#88, #109)
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add option to overrule config setting at runtime (#92)
 - If image period is e.g. "weekly", align `start_date` of a marker to the next monday
   instead of the previous one to avoid using data outside the dates provided (#83, #84)
+- Add method "best available pixel" on openeo for S2 (#70)
 - Add utility script to recalculate reports for an existing run + make recalculation
   more robust for old runs (#91, #102, #103, #104, #106)
 - Improve pixelcount calculation for parcels (#96, #105)
@@ -19,7 +20,7 @@
 - Add whether a parcel has been used for training to output (#107)
 - Run `bulk_zonal_stats` in low priority worker processes (#81)
 - Use ruff instead of black and flake for formatting and linting (#57, #64, #65, #67)
-- Add method "best available pixel" on openeo for S2 (#70)
+- Fix pandas 3,... deprecations, warnings (#88, #109)
 
 ### Bugs fixed
 

--- a/cropclassification/postprocess/classification_reporting.py
+++ b/cropclassification/postprocess/classification_reporting.py
@@ -1158,7 +1158,7 @@ def _get_confusion_matrix_ext(df_predict, prediction_column_to_use: str):
     df_confmatrix_ext.insert(loc=2, column="nb_predicted_correct", value=0)
     for column in df_confmatrix_ext.columns:
         if column not in ["nb_input", "nb_predicted", "nb_predicted_correct"]:
-            df_confmatrix_ext.loc["nb_predicted_correct", column] = df_confmatrix_ext[
+            df_confmatrix_ext["nb_predicted_correct"][column] = df_confmatrix_ext[
                 column
             ][column]
     # Insert column with the total nb of parcel for each class that were predicted to

--- a/cropclassification/postprocess/classification_reporting.py
+++ b/cropclassification/postprocess/classification_reporting.py
@@ -1158,9 +1158,9 @@ def _get_confusion_matrix_ext(df_predict, prediction_column_to_use: str):
     df_confmatrix_ext.insert(loc=2, column="nb_predicted_correct", value=0)
     for column in df_confmatrix_ext.columns:
         if column not in ["nb_input", "nb_predicted", "nb_predicted_correct"]:
-            df_confmatrix_ext["nb_predicted_correct"][column] = df_confmatrix_ext[
-                column
-            ][column]
+            df_confmatrix_ext.at[column, "nb_predicted_correct"] = df_confmatrix_ext.at[
+                column, column
+            ]
     # Insert column with the total nb of parcel for each class that were predicted to
     # have this value (=sum of the column of each class)
     values = (


### PR DESCRIPTION
Make sure `nb_predicted_correct` gets the correct values instead of 0.

Bug introduced in #88/#89, so bug has not been released yet and doesn't need seperate entry in changelog.

resolves https://github.com/theroggy/cropclassification/issues/108