### PR TITLE
ENH: Add possibility to configure any possible parameter for the supported sklearn based classifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,28 @@
 
 ## ???
 
+### Deprecations and compatibility notes
+
+- To provide the possibility to specify any hyperparameter for sklearn classifiers, the
+  parameters will now have to be specified as a json string instead of in individual
+  parameters when such a classifier is used. Because of this, the following parameters
+  become obsolete + the default values will become the default values in sklearn (#110):
+    - randomforest_n_estimators: default 100 instead of 200
+    - randomforest_max_depth: default None instead of 35
+    - multilayer_perceptron_hidden_layer_sizes: default (100,) instead of (100, 100)
+    - multilayer_perceptron_max_iter: default 200 instead of 1000
+    - multilayer_perceptron_learning_rate_init
+
 ### Improvements
 
 - Add task/action to automate periodic download of images (#67)
 - Add support to calculate indexes locally (#55)
 - Improve config and handling of "weekly" and "biweekly" raster image periods (#78)
+- Add possibility to configure any possible hyperparameter for the supported sklearn
+  based classifiers (#110)
 - Add support for HistGradientBoostingClassifier (#95)
 - Make image profiles to be used in a classification configurable in a config file (#56)
-- Add option to overrule config setting at runtime (#92)
+- Add option to overrule configuration parameters at runtime (#92)
 - If image period is e.g. "weekly", align `start_date` of a marker to the next monday
   instead of the previous one to avoid using data outside the dates provided (#83, #84)
 - Add method "best available pixel" on openeo for S2 (#70)

--- a/cropclassification/general.ini
+++ b/cropclassification/general.ini
@@ -213,18 +213,14 @@ classifier_sklearn_kwargs
 # The extension of the file format to save the trained model to
 classifier_ext = .hdf5
 
-# For multilayer_perceptron, the hidden layer size(s) (as a komma seperated list)
+# For keras_multilayer_perceptron, hidden layer size(s) as a komma seperated list
 multilayer_perceptron_hidden_layer_sizes = 100, 100
-# For multilayer_perceptron, the percentage dropout to use between the hidden layers
+# For keras_multilayer_perceptron: percentage dropout to use between the hidden layers
 multilayer_perceptron_dropout_pct = 30
-# For multilayer_perceptron, the maximum number of iterations when training
+# For multilayer_perceptronkeras_multilayer_perceptron: the max number of iterations
+# when training
 multilayer_perceptron_max_iter = 1000
 multilayer_perceptron_learning_rate_init = 0.001
-
-# For randomforest, the maximum number of trees to create
-randomforest_n_estimators = 200
-# For randomforest, the maximum depth of trees to create
-randomforest_max_depth = 35
 
 [postprocess]
 # Doubt: if highest probability < 2*second probability  

--- a/cropclassification/general.ini
+++ b/cropclassification/general.ini
@@ -200,6 +200,16 @@ min_parcels_in_class = 50
 #     * randomforest (sklearn)
 #     * svm (sklearn)
 classifier_type = keras_multilayer_perceptron
+
+# For all sklearn based classifiers, any kwargs supported by the classifier chosen can
+# be specified as a json parameter, e.g. for randomforest:
+# classifier_sklearn_kwargs = {
+#         "n_estimators": 100,
+#         "max_depth": 35,
+#         "min_samples_split": 10
+#     }
+classifier_sklearn_kwargs
+
 # The extension of the file format to save the trained model to
 classifier_ext = .hdf5
 

--- a/cropclassification/helpers/config_helper.py
+++ b/cropclassification/helpers/config_helper.py
@@ -133,7 +133,7 @@ def read_config(
             "list": lambda x: [i.strip() for i in x.split(",")],
             "listint": lambda x: [int(i.strip()) for i in x.split(",")],
             "listfloat": lambda x: [float(i.strip()) for i in x.split(",")],
-            "dict": lambda x: json.loads(x),
+            "dict": lambda x: None if x is None else json.loads(x),
             "path": lambda x: None if x is None else Path(x),
         },
         allow_no_value=True,

--- a/cropclassification/predict/classification_sklearn.py
+++ b/cropclassification/predict/classification_sklearn.py
@@ -62,6 +62,8 @@ def train(train_df: pd.DataFrame, output_classifier_basepath: Path) -> Path:
     logger.info("Start training")
     classifier_type_lower = conf.classifier["classifier_type"].lower()
     classifier_kwargs = conf.classifier.getdict("classifier_sklearn_kwargs")
+    if classifier_kwargs is None:
+        classifier_kwargs = {}
     if classifier_type_lower == "randomforest":
         if "n_jobs" not in classifier_kwargs:
             classifier_kwargs["n_jobs"] = conf.general.getint("nb_parallel")


### PR DESCRIPTION
To provide the possibility to specify any hyperparameter for sklearn classifiers, the
  parameters will now have to be specified as a json string instead of in individual
  parameters when such a classifier is used. Because of this, the following parameters
  become obsolete + the default values will become the default values in sklearn (#110):

    - randomforest_n_estimators: default 100 instead of 200
    - randomforest_max_depth: default None instead of 35
    - multilayer_perceptron_hidden_layer_sizes: default (100,) instead of (100, 100)
    - multilayer_perceptron_max_iter: default 200 instead of 1000
    - multilayer_perceptron_learning_rate_init