### PR TITLE
ENH: improve configurability + defaults of keras mlp classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
     - multilayer_perceptron_hidden_layer_sizes: default (100,) instead of (100, 100)
     - multilayer_perceptron_max_iter: default 200 instead of 1000
     - multilayer_perceptron_learning_rate_init
+- For keras multilayer perceptron, some changes were applied to the default
+  hyperparameters (#115)
 
 ### Improvements
 
@@ -22,6 +24,7 @@
 - Add possibility to configure any possible hyperparameter for the supported sklearn
   based classifiers (#110)
 - Add support for HistGradientBoostingClassifier (#95)
+- Improve configurability + defaults of keras mlp classifier (#115)
 - Make image profiles to be used in a classification configurable in a config file (#56)
 - Add option to overrule configuration parameters at runtime (#92)
 - If image period is e.g. "weekly", align `start_date` of a marker to the next monday

--- a/cropclassification/general.ini
+++ b/cropclassification/general.ini
@@ -204,7 +204,7 @@ classifier_type = keras_multilayer_perceptron
 # For all sklearn based classifiers, any kwargs supported by the classifier chosen can
 # be specified as a json parameter, e.g. for randomforest:
 # classifier_sklearn_kwargs = {
-#         "n_estimators": 100,
+#         "n_estimators": 200,
 #         "max_depth": 35,
 #         "min_samples_split": 10
 #     }
@@ -214,13 +214,21 @@ classifier_sklearn_kwargs
 classifier_ext = .hdf5
 
 # For keras_multilayer_perceptron, hidden layer size(s) as a komma seperated list
-multilayer_perceptron_hidden_layer_sizes = 100, 100
+# The {input_layer_size} can be used as placeholder and will be replaced by the number
+# of input features (columns) that will be used. Using simple math is also supported.
+multilayer_perceptron_hidden_layer_sizes = {input_layer_size}*2, {input_layer_size}*2, {input_layer_size}
 # For keras_multilayer_perceptron: percentage dropout to use between the hidden layers
-multilayer_perceptron_dropout_pct = 30
-# For multilayer_perceptronkeras_multilayer_perceptron: the max number of iterations
+multilayer_perceptron_dropout_pct = 10
+# For keras_multilayer_perceptron: the max number of iterations
 # when training
 multilayer_perceptron_max_iter = 1000
 multilayer_perceptron_learning_rate_init = 0.001
+# For keras, the strategy to choose the best model. Options:
+#   - VAL_LOSS: choose the model with the lowest validation loss
+#   - LOSS: choose the model with the lowest train loss
+#   - AVG(VAL_LOSS,LOSS): choose the model with the lowest average of validation and
+#     training loss
+best_model_strategy = VAL_LOSS
 
 [postprocess]
 # Doubt: if highest probability < 2*second probability  


### PR DESCRIPTION
Most important changes:
- Change default hidden layers from 100, 100 to {input_layer_size}*2, {input_layer_size}*2, {input_layer_size}
- Change default dropout rate from 30% to 10%