### PR TITLE
ENH: change default value for timeseries.min_parcels_with_data_pct to 80

### DIFF
--- a/cropclassification/general.ini
+++ b/cropclassification/general.ini
@@ -177,7 +177,7 @@ image_profiles_config_filepath = ${dirs:marker_basedir}/_config/image_profiles.i
 max_cloudcover_pct = 15
 
 # The min percentage of parcels that need to have valid data for a time+sensor to use it 
-min_parcels_with_data_pct = 90
+min_parcels_with_data_pct = 80
 
 [preprocess]
 # 


### PR DESCRIPTION
Because sentinel 1B has is out of service, there are some locations that don't get a weekly full coverage. In some weeks only slightly more than 80% of area is covered... so adapt default to this value.