### PR TITLE
ENH: add feature cross-prediction-models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Deprecations and compatibility notes
 
+- Add feature "cross-prediction-models" to avoid markers being calculated on parcels
+  using a model that used this parcel in its training (#142)
 - Consolidated some landcover pre-processing ignore codes (#120)
 - Restructure + cleanup of configuration file, mainly to avoid duplicate keys and to
   improve parameter names:

--- a/cropclassification/calc_marker.py
+++ b/cropclassification/calc_marker.py
@@ -10,8 +10,10 @@ from pathlib import Path
 
 # Import geofilops here already, if tensorflow is loaded first leads to dll load errors
 import geofileops as gfo  # noqa: F401
+import pandas as pd
 import pyproj
 
+import cropclassification.helpers.pandas_helper as pdh
 from cropclassification.helpers import config_helper as conf
 from cropclassification.helpers import dir_helper, log_helper
 from cropclassification.helpers import model_helper as mh
@@ -266,53 +268,134 @@ def calc_marker_task(
     parcel_predictions_proba_all_path = (
         run_dir / f"{base_filename}_predict_proba_all{data_ext}"
     )
+    parcel_predictions_proba_test_path = (
+        run_dir / f"{base_filename}_predict_proba_test{data_ext}"
+    )
+    cross_models = conf.classifier.get("cross_models", 1)
+    cross_models = (
+        1 if cross_models is None or int(cross_models) < 1 else int(cross_models)
+    )
     classifier_ext = conf.classifier["classifier_ext"]
-    classifier_basepath = run_dir / f"{markertype}_01_mlp{classifier_ext}"
+    cross_model_id_column = conf.columns["cross_model_id"]
+    parcel_test_path = None
+    parcel_train_path = None
 
-    # Check if a model exists already
-    if input_model_to_use_path is None:
-        best_model = mh.get_best_model(run_dir, acc_metric_mode="min")
-        if best_model is not None:
-            input_model_to_use_path = best_model["path"]
+    # If the predictions file doesn't exist, do the classification
+    if not parcel_predictions_proba_all_path.exists():
+        if cross_models > 1:
+            # Use "cross models": train multiple models, so prediction of a parcel is
+            # always done with a model where the parcel wasn't used to train it.
 
-    # if there is no model to use specified, train one!
-    parcel_train_path = run_dir / f"{base_filename}_parcel_train{data_ext}"
-    parcel_test_path = run_dir / f"{base_filename}_parcel_test{data_ext}"
-    parcel_predictions_proba_test_path = None
-    if input_model_to_use_path is None:
-        # Create the training sample...
-        # Remark: this creates a list of representative test parcel + a list of
-        # (candidate) training parcel
-        balancing_strategy = conf.marker["balancing_strategy"]
-        class_pre.create_train_test_sample(
-            input_parcel_path=parcel_path,
-            output_parcel_train_path=parcel_train_path,
-            output_parcel_test_path=parcel_test_path,
-            balancing_strategy=balancing_strategy,
-        )
+            # Assign each parcel to a model where it will be predicted with.
+            gfo.add_column(
+                path=parcel_path,
+                name=cross_model_id_column,
+                type="int",
+                expression=f"ABS(RANDOM() % {cross_models})",
+            )
+            if input_model_to_use_path is not None:
+                raise ValueError(
+                    "cross_models not supported with input_model_to_use_path"
+                )
 
-        # Train the classifier and output predictions
-        parcel_predictions_proba_test_path = (
-            run_dir / f"{base_filename}_predict_proba_test{data_ext}"
-        )
-        classification.train_test_predict(
-            input_parcel_train_path=parcel_train_path,
-            input_parcel_test_path=parcel_test_path,
-            input_parcel_all_path=parcel_path,
-            input_parcel_classification_data_path=parcel_classification_data_path,
-            output_classifier_basepath=classifier_basepath,
-            output_predictions_test_path=parcel_predictions_proba_test_path,
-            output_predictions_all_path=parcel_predictions_proba_all_path,
-        )
-    else:
-        # there is a classifier specified, so just use it!
-        classification.predict(
-            input_parcel_path=parcel_path,
-            input_parcel_classification_data_path=parcel_classification_data_path,
-            input_classifier_basepath=classifier_basepath,
-            input_classifier_path=input_model_to_use_path,
-            output_predictions_path=parcel_predictions_proba_all_path,
-        )
+        pred_test_files = []
+        pred_all_files = []
+        for cross_model_idx in range(cross_models):
+            if cross_models == 1:
+                # Only one model, so no need to create subdirectory
+                model_dir = run_dir
+
+                # Output can be the final file immediately
+                parcel_preds_proba_test_model_path = parcel_predictions_proba_test_path
+                parcel_preds_proba_all_model_path = parcel_predictions_proba_all_path
+
+                # No need to filter percels based on cross model indexes
+                training_query = None
+                predict_query = None
+            else:
+                # Create a subfolder for each model
+                model_dir = run_dir / f"cross_model_{cross_model_idx}"
+                model_dir.mkdir(parents=True, exist_ok=True)
+
+                # Temporary output files in the subdirectory
+                parcel_preds_proba_test_model_path = (
+                    model_dir / parcel_predictions_proba_test_path.name
+                )
+                pred_test_files.append(parcel_preds_proba_test_model_path)
+                parcel_preds_proba_all_model_path = (
+                    model_dir / parcel_predictions_proba_all_path.name
+                )
+                pred_all_files.append(parcel_preds_proba_all_model_path)
+
+                # The training will be done on all parcels with another index
+                training_cross_model_ids = [
+                    idx for idx in range(cross_models) if idx != cross_model_idx
+                ]
+                training_query = (
+                    f"{cross_model_id_column} in {training_cross_model_ids}"
+                )
+                predict_query = f"{cross_model_id_column} == {cross_model_idx}"
+
+            # Check if a model exists already
+            if input_model_to_use_path is None:
+                best_model = mh.get_best_model(model_dir, acc_metric_mode="min")
+                if best_model is not None:
+                    input_model_to_use_path = best_model["path"]
+
+            # If we cannot reuse an existing model, train one!
+            parcel_train_path = model_dir / f"{base_filename}_parcel_train{data_ext}"
+            parcel_test_path = model_dir / f"{base_filename}_parcel_test{data_ext}"
+            classifier_basepath = model_dir / f"{markertype}_01_mlp{classifier_ext}"
+            if input_model_to_use_path is None:
+                # Create the training sample.
+                # Remark: this creates a list of representative test parcel + a list of
+                # (candidate) training parcel
+                balancing_strategy = conf.marker["balancing_strategy"]
+                class_pre.create_train_test_sample(
+                    input_parcel_path=parcel_path,
+                    output_parcel_train_path=parcel_train_path,
+                    output_parcel_test_path=parcel_test_path,
+                    balancing_strategy=balancing_strategy,
+                    training_query=training_query,
+                )
+
+                # Train the classifier and output predictions
+                classification.train_test_predict(
+                    input_parcel_train_path=parcel_train_path,
+                    input_parcel_test_path=parcel_test_path,
+                    input_parcel_all_path=parcel_path,
+                    input_parcel_classification_data_path=parcel_classification_data_path,
+                    output_classifier_basepath=classifier_basepath,
+                    output_predictions_test_path=parcel_preds_proba_test_model_path,
+                    output_predictions_all_path=parcel_preds_proba_all_model_path,
+                    predict_query=predict_query,
+                )
+            else:
+                # There exists already a classifier, so just use it!
+                classification.predict(
+                    input_parcel_path=parcel_path,
+                    input_parcel_classification_data_path=parcel_classification_data_path,
+                    input_classifier_basepath=classifier_basepath,
+                    input_classifier_path=input_model_to_use_path,
+                    output_predictions_path=parcel_preds_proba_all_model_path,
+                    predict_query=predict_query,
+                )
+
+        # Merge all prediction to single output file
+        if cross_models > 1:
+            # Merge all test predictions to single output file
+            pred_test_df = None
+            for path in pred_test_files:
+                df = pdh.read_file(path)
+                pred_test_df = pd.concat([pred_test_df, df], ignore_index=True)
+            pdh.to_file(pred_test_df, parcel_predictions_proba_test_path, index=False)
+
+            # Merge all "all" predictions to single output file
+            pred_all_df = None
+            for path in pred_all_files:
+                df = pdh.read_file(path)
+                pred_all_df = pd.concat([pred_all_df, df], ignore_index=True)
+            pdh.to_file(pred_all_df, parcel_predictions_proba_all_path, index=False)
 
     # STEP 5: if necessary, do extra postprocessing
     # -------------------------------------------------------------

--- a/cropclassification/calc_marker.py
+++ b/cropclassification/calc_marker.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 
 # Import geofilops here already, if tensorflow is loaded first leads to dll load errors
-import geofileops as gfo  # noqa: F401
+import geofileops as gfo
 import pandas as pd
 import pyproj
 

--- a/cropclassification/general.ini
+++ b/cropclassification/general.ini
@@ -211,16 +211,17 @@ min_parcels_in_class = 50
 # Configuration of marker classifier parameters.
 [classifier]
 
-# The number of cross-models to use for this marker.
+# The number of cross-prediction-models to use for this marker.
 #
-# If cross_models is None (the default) or <= 1, , no cross-models are used.
+# If cross_pred_models is None (the default) or <= 1, , no cross-prediction models are
+# used.
 #
-# The cross-models feature can be used to avoid predicting a marker on a
+# The cross-prediction-models feature can be used to avoid predicting a marker on a
 # parcel where the parcel was part of the training dataset.
-# When cross_models = 2, the input data is split in 2 (per class). Each 50% of
+# When cross_pred_models = 2, the input data is split in 2 (per class). Each 50% of
 # the data will be used to train one model, and this model will be used to
 # predict the other 50% of the parcels.
-cross_models
+cross_pred_models
 
 # The classifier type to use. Currently supported types:
 #     * histgradientboostingclassifier (sklearn)
@@ -336,7 +337,7 @@ prediction_conclusion_detail_full_alpha = pred_conclusion_detail_full_alpha
 prediction_conclusion_cons = pred_conclusion_cons
 
 # Column name with the cross model index.
-cross_model_id = cross_model_id
+cross_pred_model_id = cross_pred_model_id
 
 # Configuration of paths to use to find/save input/output files.
 [paths]

--- a/cropclassification/general.ini
+++ b/cropclassification/general.ini
@@ -211,6 +211,17 @@ min_parcels_in_class = 50
 # Configuration of marker classifier parameters.
 [classifier]
 
+# The number of cross-models to use for this marker.
+#
+# If cross_models is None (the default) or <= 1, , no cross-models are used.
+#
+# The cross-models feature can be used to avoid predicting a marker on a
+# parcel where the parcel was part of the training dataset.
+# When cross_models = 2, the input data is split in 2 (per class). Each 50% of
+# the data will be used to train one model, and this model will be used to
+# predict the other 50% of the parcels.
+cross_models
+
 # The classifier type to use. Currently supported types:
 #     * histgradientboostingclassifier (sklearn)
 #     * keras_multilayer_perceptron (tensorflow)
@@ -323,6 +334,9 @@ prediction_conclusion_detail_cons = pred_conclusion_detail_cons
 prediction_conclusion_detail_full_alpha = pred_conclusion_detail_full_alpha
 # Column name of the conclusion based on consolidated prediction
 prediction_conclusion_cons = pred_conclusion_cons
+
+# Column name with the cross model index.
+cross_model_id = cross_model_id
 
 # Configuration of paths to use to find/save input/output files.
 [paths]

--- a/cropclassification/helpers/pandas_helper.py
+++ b/cropclassification/helpers/pandas_helper.py
@@ -111,7 +111,7 @@ def read_file(
 
 
 def to_file(
-    df: Union[pd.DataFrame, pd.Series],
+    df: Optional[Union[pd.DataFrame, pd.Series]],
     path: Path,
     table_name: str = "info",
     index: bool = True,

--- a/cropclassification/helpers/pandas_helper.py
+++ b/cropclassification/helpers/pandas_helper.py
@@ -124,6 +124,9 @@ def to_file(
     # TODO: think about if possible/how to support  adding optional parameter and pass
     # them to next function, example encoding, float_format,...
     """
+    if df is None:
+        raise ValueError("Dataframe df is None")
+
     ext_lower = path.suffix.lower()
     if ext_lower == ".csv":
         if append:

--- a/cropclassification/predict/classification.py
+++ b/cropclassification/predict/classification.py
@@ -228,7 +228,7 @@ def predict(
         conf.columns["class_declared"],
     ]
     if predict_query is not None:
-        columns.append(conf.columns["cross_model_id"])
+        columns.append(conf.columns["cross_pred_model_id"])
     input_parcel_df = pdh.read_file(input_parcel_path, columns=columns)
     if input_parcel_df.index.name != conf.columns["id"]:
         input_parcel_df.set_index(conf.columns["id"], inplace=True)
@@ -236,7 +236,9 @@ def predict(
     if predict_query is not None:
         logger.info(f"Filter predict parcels with query: {predict_query}")
         input_parcel_df = input_parcel_df.query(predict_query)
-        input_parcel_df = input_parcel_df.drop(columns=[conf.columns["cross_model_id"]])
+        input_parcel_df = input_parcel_df.drop(
+            columns=[conf.columns["cross_pred_model_id"]]
+        )
     logger.debug("Read predict input file ready")
 
     # For parcels of a class that should be ignored, don't predict

--- a/cropclassification/preprocess/classification_preprocess.py
+++ b/cropclassification/preprocess/classification_preprocess.py
@@ -18,8 +18,6 @@ import cropclassification.preprocess._classification_preprocess_BEFL as befl
 # Get a logger...
 logger = logging.getLogger(__name__)
 
-CROSS_MODEL_IDX_COLUMN = "cross_model_idx"
-
 
 def prepare_input(
     input_parcel_path: Path,
@@ -154,8 +152,8 @@ def create_train_test_sample(
     logger.info(f"Read input file {input_parcel_path}")
     df_in = pdh.read_file(input_parcel_path)
 
-    # If training_cross_model_indexes is not None, only keep the parcels that have one
-    # of the indexes specified
+    # If training_cross_pred_model_indexes is not None, only keep the parcels that have
+    # one of the indexes specified
     if training_query is not None:
         logger.info(f"Filter parcels with {training_query=}")
         df_in = df_in.query(training_query)

--- a/cropclassification/preprocess/classification_preprocess.py
+++ b/cropclassification/preprocess/classification_preprocess.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
+from typing import Optional
 
 import geofileops as gfo
 import pandas as pd
@@ -14,16 +15,10 @@ import cropclassification.helpers.config_helper as conf
 import cropclassification.helpers.pandas_helper as pdh
 import cropclassification.preprocess._classification_preprocess_BEFL as befl
 
-# -------------------------------------------------------------
-# First define/init some general variables/constants
-# -------------------------------------------------------------
-
 # Get a logger...
 logger = logging.getLogger(__name__)
 
-# -------------------------------------------------------------
-# The real work
-# -------------------------------------------------------------
+CROSS_MODEL_IDX_COLUMN = "cross_model_idx"
 
 
 def prepare_input(
@@ -135,11 +130,12 @@ def create_train_test_sample(
     output_parcel_train_path: Path,
     output_parcel_test_path: Path,
     balancing_strategy: str,
+    training_query: Optional[str] = None,
     force: bool = False,
 ):
     """Create a seperate train and test sample from the general input file."""
 
-    # If force == False Check and the output files exist already, stop.
+    # If force False and the output files exist already, stop.
     if (
         force is False
         and output_parcel_train_path.exists() is True
@@ -157,6 +153,13 @@ def create_train_test_sample(
     )
     logger.info(f"Read input file {input_parcel_path}")
     df_in = pdh.read_file(input_parcel_path)
+
+    # If training_cross_model_indexes is not None, only keep the parcels that have one
+    # of the indexes specified
+    if training_query is not None:
+        logger.info(f"Filter parcels with {training_query=}")
+        df_in = df_in.query(training_query)
+
     logger.debug(f"Read input file ready, shape: {df_in.shape}")
 
     # Init some many-used variables from config


### PR DESCRIPTION
The cross-prediction-models feature can be used to avoid predicting a marker on a parcel where the parcel was part of the training dataset.

When the number of cross_pred_models = 2 for example, the input data is split in 2 (per class). Each 50% of the data will be used to train one model, and this model will be used to predict the other 50% of the parcels.