### PR TITLE
CI: limit pandas-stubs to <= 2.3 for now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: ruff
         # args: [ --fix ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.15.0"
+    rev: "v1.17.1"
     hooks:
       - id: mypy
-        additional_dependencies: [pandas-stubs, types-python-dateutil, types-requests]
+        additional_dependencies: [pandas-stubs<2.3, types-python-dateutil, types-requests]

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -29,7 +29,7 @@ dependencies:
   - pytest-cov
   # linting
   - mypy ==1.15.0
-  - pandas-stubs
+  - pandas-stubs <=2.3
   - pre-commit
   - ruff ==0.9.7
   - types-python-dateutil


### PR DESCRIPTION
Probably keeping pandas and pandas-stubs version in sync should be forced in the pandas-stubs conda package. Opened an issue for this: https://github.com/conda-forge/pandas-stubs-feedstock/issues/153

For now, this PR limits the version here to avoid mypy errors in pre-commit.
