### PR TITLE
BUG: fix encoding error when reading sqlite files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 
 - Fix `calc_periodic_mosaic_task` to read `roi_bounds` parameter as list of floats from
   config (#130)
+- Fix encoding error when reading sqlite files (#196)
 
 ## 0.2.0 (2024-06-17)
 

--- a/cropclassification/helpers/pandas_helper.py
+++ b/cropclassification/helpers/pandas_helper.py
@@ -106,7 +106,11 @@ def read_file(
         return pd.read_parquet(str(path), columns=columns)
     elif ext_lower in (".sqlite", ".gpkg"):
         return pyogrio.read_dataframe(
-            path, columns=columns, read_geometry=not ignore_geometry, sql=sql
+            path,
+            columns=columns,
+            read_geometry=not ignore_geometry,
+            sql=sql,
+            encoding="utf-8",
         )
     else:
         raise ValueError(f"Not implemented for extension {ext_lower}")

--- a/cropclassification/preprocess/_prepare_input_BEFL.py
+++ b/cropclassification/preprocess/_prepare_input_BEFL.py
@@ -8,7 +8,6 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import geofileops as gfo
 from typing_extensions import deprecated
 
 import cropclassification.helpers.config_helper as conf
@@ -86,9 +85,8 @@ def prepare_input(
 
     # Read input file
     logger.info(f"Read parceldata from {input_parcel_path}")
-    # parceldata_df = gfo.read_file(input_parcel_path)
     parceldata_df = pdh.read_file(input_parcel_path)
-    logger.info(f"Read Parceldata ready, info(): {parceldata_df.info()}")
+    logger.info(f"Read Parceldata ready, {len(parceldata_df)=}")
 
     # Check if the id column is present...
     if conf.columns["id"] not in parceldata_df.columns:

--- a/cropclassification/preprocess/_prepare_input_BEFL.py
+++ b/cropclassification/preprocess/_prepare_input_BEFL.py
@@ -86,7 +86,8 @@ def prepare_input(
 
     # Read input file
     logger.info(f"Read parceldata from {input_parcel_path}")
-    parceldata_df = gfo.read_file(input_parcel_path)
+    # parceldata_df = gfo.read_file(input_parcel_path)
+    parceldata_df = pdh.read_file(input_parcel_path)
     logger.info(f"Read Parceldata ready, info(): {parceldata_df.info()}")
 
     # Check if the id column is present...

--- a/cropclassification/preprocess/_timeseries_helper.py
+++ b/cropclassification/preprocess/_timeseries_helper.py
@@ -118,6 +118,8 @@ def prepare_input(
         temp_empty_path = (
             temp_output_dir / f"{output_imagedata_parcel_input_path.stem}_empty.sqlite"
         )
+        if temp_empty_path.exists():
+            gfo.remove(temp_empty_path)
         pdh.to_file(parceldata_buf_empty_df, temp_empty_path)
 
     # Export parcels that don't result in an empty geometry


### PR DESCRIPTION
Not sure why, but reading an .sqlite file recently started giving encoding errors ("cp1252" decoding error). This PR forces .sqlite files being read as `encoding="utf-8"` which seems to solve the problem.