### PR TITLE
ENH: avoid high committed memory for zonal stats calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Add LATECROP-LATE detection (#177)
 - Add support for groundtruth data processing for latecrop marker (#193)
 - Add POC (not for operational use) of a cover/bare soil marker (#168)
+- Avoid high committed memory for zonal stats calculation (#197)
 - General small improvements, e.g. save randomforest models compressed,.. (#144)
 
 ### Bugs fixed

--- a/cropclassification/util/zonal_stats_bulk/_processing_util.py
+++ b/cropclassification/util/zonal_stats_bulk/_processing_util.py
@@ -44,6 +44,14 @@ class PooledExecutorFactory:
 
 
 def initialize_worker():
+    """Some default inits for workers."""
+    # Reduce OpenMP threads to avoid the committed memory usage becoming huge when using
+    # multiprocessing.
+    # Should work for any numeric library used (openblas, mkl,...).
+    # Ref: https://stackoverflow.com/questions/77764228/pandas-scipy-high-commit-memory-usage-windows
+    if os.environ.get("OMP_NUM_THREADS") is None:
+        os.environ["OMP_NUM_THREADS"] = "1"
+
     # We don't want the workers to block the entire system, so make them nice
     # if they aren't quite nice already.
     # Remark: on linux, depending on system settings it is not possible to


### PR DESCRIPTION
The memory commited in windows was problematic, a bit worse for for exactextract, but also for the other zonal stats calculations: ~20 GB commited memory (not in use) per parallel process.
- on windows the processing crashed with nb_parallel=8 on an 128 GB RAM workstation. 
- not tested on linux, but linux allows overcommitting, but based on a google warnings are emitted when a high overcommit rate is detected...

Apparently this is (mainly) caused by numpy/openblas creating a thread pool for the 24 logical processors in each of the 8 (or 9) processes. Setting `os.environ["OMP_NUM_THREADS"] = "1"` in the workers seems to solve the issue.
- Reference: https://stackoverflow.com/questions/77764228/pandas-scipy-high-commit-memory-usage-windows